### PR TITLE
Link to Code from reader view, show correct nc values for instance on About page

### DIFF
--- a/lib/exbin_web/templates/layout/app.html.eex
+++ b/lib/exbin_web/templates/layout/app.html.eex
@@ -60,11 +60,17 @@
                   <%= link raw(~s'<i class="fa fa-trash"></i> Delete'), to: page_path(@conn, :delete, @snippet.name), class: "nav-link", method: "delete"  %>
                </li>
                <% end %>
+               <%= if is_reader_view(@conn) do %>
+               <li class="nav-item active mr-05">
+                  <%= link raw(~s'<i class="fa fa-code"></i> Code'), to: page_path(@conn, :code, @snippet.name), class: "nav-link"  %>
+               </li>
+               <% else %>
                <li class="nav-item active mr-05">
                   <%= link raw(~s'<i class="fa fa-book"></i> Reader'), to: page_path(@conn, :reader, @snippet.name), class: "nav-link"  %>
                </li>
+               <% end %>
                <li class="nav-item active mr-05">
-                  <%= link raw(~s'<i class="fa fa-code"></i> Raw'), to: page_path(@conn, :raw, @snippet.name), class: "nav-link"  %>
+                  <%= link raw(~s'<i class="fa fa-terminal"></i> Raw'), to: page_path(@conn, :raw, @snippet.name), class: "nav-link"  %>
                </li>
                <li class="nav-item active navbar-right mr-05">
                   <a class="nav-link"><i class="fa fa-eye"></i> <%= @snippet.viewcount %></a>

--- a/lib/exbin_web/templates/page/about.html.eex
+++ b/lib/exbin_web/templates/page/about.html.eex
@@ -31,8 +31,8 @@
                Netcat
             </h2>
             <p>
-               Exbin also support netcatting a textfile. Suppose you are configuring some server and you quickly want to
-               get data out to your other workstation. You can pipe the file to exbin, and manually type over an
+               ExBin also support netcatting a textfile. Suppose you are configuring some server and you quickly want to
+               get data out to your other workstation. You can pipe the file to ExBin, and manually type over an
                easy-to-read URL. For example <code>cat myfile.txt | nc <%= ExBinWeb.Endpoint.url() %> <%= Application.get_env(:exbin, :tcp_port) %></code> will return a URL to
                your console which you can type over. All these pastes are private, of course!
             </p>

--- a/lib/exbin_web/templates/page/about.html.eex
+++ b/lib/exbin_web/templates/page/about.html.eex
@@ -33,7 +33,7 @@
             <p>
                Exbin also support netcatting a textfile. Suppose you are configuring some server and you quickly want to
                get data out to your other workstation. You can pipe the file to exbin, and manually type over an
-               easy-to-read URL. For example <code>cat myfile.txt | nc exbin.call-cc.be 9999</code> will return a URL to
+               easy-to-read URL. For example <code>cat myfile.txt | nc <%= ExBinWeb.Endpoint.url() %> <%= Application.get_env(:exbin, :tcp_port) %></code> will return a URL to
                your console which you can type over. All these pastes are private, of course!
             </p>
          </div>

--- a/lib/exbin_web/views/layout_view.ex
+++ b/lib/exbin_web/views/layout_view.ex
@@ -1,3 +1,7 @@
 defmodule ExBinWeb.LayoutView do
   use ExBinWeb, :view
+
+  def is_reader_view(conn = %Plug.Conn{path_info: path_info}) do
+    List.first(path_info) == "reader"
+  end
 end


### PR DESCRIPTION
Note that this change changes the icon for Raw view from fa-code to fa-terminal. I did this arbitrarily and I'm still torn on if it's the right choice. I thought about keeping fa-code for Raw and using fa-terminal for Code, but it just didn't look as right to me, and I didn't really love any of the other icons to go with Code. Switch it around if if you've got a better idea!

This resolves both #23 and #24.