### PR TITLE
Fix about page to only show hostname, not full URL

### DIFF
--- a/lib/exbin_web/templates/page/about.html.eex
+++ b/lib/exbin_web/templates/page/about.html.eex
@@ -33,7 +33,7 @@
             <p>
                ExBin also support netcatting a textfile. Suppose you are configuring some server and you quickly want to
                get data out to your other workstation. You can pipe the file to ExBin, and manually type over an
-               easy-to-read URL. For example <code>cat myfile.txt | nc <%= ExBinWeb.Endpoint.url() %> <%= Application.get_env(:exbin, :tcp_port) %></code> will return a URL to
+               easy-to-read URL. For example <code>cat myfile.txt | nc <%= ExBinWeb.Endpoint.host() %> <%= Application.get_env(:exbin, :tcp_port) %></code> will return a URL to
                your console which you can type over. All these pastes are private, of course!
             </p>
          </div>


### PR DESCRIPTION
I'm really sorry to have created the extra work for you here, but I realized that the way I implemented the last PR generated the endpoint URL, which includes the http(s)://, which will cause nc to fail if you copy-paste the example code. :cry: 

This fixes it to just show the the Endpoint.host, which should be just the host, and should match the EXTERNAL_URL env variable (per config/prod.exs), and correctly generate the `| nc my.snip.host 9999` string.

Sorry for the screwup!