### PR TITLE
Change About page to show correct ephemeral age.

### DIFF
--- a/lib/exbin_web/templates/page/about.html.eex
+++ b/lib/exbin_web/templates/page/about.html.eex
@@ -21,7 +21,7 @@
       Duration
    </h2>
    <p>
-      Pastes are stored indefinitely, unless they are marked as “ephemeral”. In that case they are removed after 12 hours.
+      Pastes are stored indefinitely, unless they are marked as “ephemeral”. In that case they are removed approximately <%= Timex.Duration.from_minutes(Application.get_env(:exbin, :ephemeral_age)) |> Timex.Format.Duration.Formatters.Humanized.format %> after creation.
    </p>
 
    <h2>


### PR DESCRIPTION
Ephemeral age on about page was wrong, now it will never be again. :smile:

Also changes the wording on their deletion a bit so it makes more sense if
the user has a value such as 65, which Timex would humanize as "1 hour,
5 minutes". Also indicates that the deletion is approximate, hopefully
preventing any "it didn't delete at *exactly* 60 minute" issues being
opened. 