### PR TITLE
Make the EPHEMERAL_AGE env var truly optional

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -15,7 +15,7 @@ default_view =
     other -> raise "Invalid value for DEFAULT_VIEW: #{other}"
   end
 
-ephemeral_age = System.get_env("EPHEMERAL_AGE") |> String.to_integer() || 60
+ephemeral_age = String.to_integer(System.get_env("EPHEMERAL_AGE") || "60")
 brand = if System.get_env("BRAND") == nil or System.get_env("BRAND") == "", do: "ExBin", else: System.get_env("BRAND")
 
 config :exbin,


### PR DESCRIPTION
When upgrading a docker hosted instance from 0.0.7 to 0.1.4 I ran into the following error:

```
  * 1st argument: not a binary

    :erlang.binary_to_integer(nil)
```

Based on #28 I discovered that ENV variable names had changed and I needed to add some new ones, so I consulted the documentation and added all required variables. However the issue persisted.

So, after reviewing releases.exs I decided to add the "optional" EPHEMERAL_AGE variable to my deployment, and the deployment worked great.

This PR resolves this issue by copying the same technique that was used for the optional "POOL_SIZE" variable and applying it to EPHEMERAL_AGE. This *should* work, since it works for POOL_SIZE, however I will admit that I did not write a test case to cover detecting if either was actually optional. :smile: