### PR TITLE
No flickering icons

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -109,9 +109,15 @@ hr {
     font-size: 1rem;
 }
 
+.menu-entry .icon {
+    display: inline-block;
+    height: 16px;
+    width: 16px;
+    margin-right: 1rem;
+}
+
 .menu-entry .icon svg {
     vertical-align: middle;
-    margin-right: 1rem;
 }
 
 .menu-entry .title {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -130,6 +130,24 @@ hr {
     margin: 0;
     border: 2px solid transparent;
     border-radius: 1px !important;
+    margin-top: .5rem;
+    margin-bottom: 2rem;
+    position: relative;
+}
+
+.alert .icon_container {
+  padding: 0;
+  margin: 0;
+  margin-right: 0.5rem;
+  display: inline-block;
+  min-height: 48px;
+  min-width: 48px;
+}
+
+.alert .message {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .alert-info {

--- a/lib/exbin_web/templates/layout/root.html.eex
+++ b/lib/exbin_web/templates/layout/root.html.eex
@@ -13,12 +13,20 @@
 
 <body>
   <main role="main" class="container-fluid">
-    <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
-    <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
-
     <div class="flex-container">
       <%# Content Column %>
         <div class="code-column">
+          <% 
+            info = get_flash(@conn, :info)
+            error = get_flash(@conn, :error)
+          %>
+          <%= if info do %>
+            <div class="alert alert-info" role="alert"><span class="icon_container"><span class="iconify" data-icon="clarity:alert-solid" data-width="48" data-height="48" style="color:#0033CC;"></span></span><span class="message"><%= info %></span></div>
+          <% end %>
+          <%= if error do %>
+            <div class="alert alert-danger" role="alert"><span class="icon_container"><span class="iconify" data-icon="akar-icons:triangle-alert-fill" data-width="48" data-height="48" style="color:#800000;"></span></span><span class="message"><%= error %></span></div>
+          <% end %>
+
           <%= @inner_content %>
         </div>
 


### PR DESCRIPTION
Prevents various forms of "flickering" or item movement while navigating around between pages.

To test the new flash alerts add
```
    conn = conn
           |> put_flash(:info, "Just so you know, that snippet looks pretty cool!")
           |> put_flash(:error, "I don't like that snippet one bit, take it back!")
```
to any of the controller's render methods. I haven't checked all the pages, but it should look okay on all of them.