### PR TITLE
add .tool-versions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 .env
+
+# Ignore ASDF-VM's local versions file
+.tool-versions


### PR DESCRIPTION
Since not everyone uses ASDF-VM, we don't want to actually commit the .tool-versions as it'll get out of date, so instead we'll ignore it so developers who use it don't accidentally commit it or anything.