### PR TITLE
Custom logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ I work on this project from time to time, so the development pace is slow. If yo
 
 ## Features
 
- * Post pastes publicly and privately 
- * Opt-in ephemeral snippets. Ephemeral snippets get deleted after 24 hours.
+ * Post pastes either publicly or privately 
+ * Opt-in ephemeral snippets. By default these are deleted approximately 60 minutes after creation.
  * Views are only incremented once every 24 hours, per client.
  * Usage statistics.
  * List of all public pastes 

--- a/README.md
+++ b/README.md
@@ -22,26 +22,29 @@ I work on this project from time to time, so the development pace is slow. If yo
 
 The easiest way to run your own instance of ExBin is by running it in a Docker container.
 
-| Environment var     | Description                                                                                | Default  |
-|---------------------|--------------------------------------------------------------------------------------------|----------|
-| `SECRET_KEY_BASE`   | Secret hash to encrypt traffic. Generate with `mix phx.gen.secret`.                        | Required |
-| `SECRET_SALT`       | Secret hash to encrypt traffic. Generate with `mix phx.gen.secret`.                        | Required |
-| `DATABASE_HOST`     | Host for database.                                                                         | Required |
-| `DATABASE_DB`       | Name of the database.                                                                      | Required |
-| `DATABASE_USER`     | Username for Postgres instance.                                                            | Required |
-| `DATABASE_PASSWORD` | Password for Postgres user.                                                                | Required |
-| `POOL_SIZE`         | Concurrent database connections.                                                           | `10`     |
-| `TZ`                | TZ database name                                                                           | Required |
-| `EPHEMERAL_AGE`     | Ephemeral age of snippets in minutes.                                                      | `60`     |
-| `HTTP_PORT`         | Port for HTTP endpoint.                                                                    | `4000`   |
-| `TCP_PORT`          | Port for the TCP endpoint.                                                                 | Required |
-| `TCP_HOST`          | IP to bind on for TCP socket.                                                              | Required |
-| `MAX_SIZE`          | Maximum size in bytes for the TCP endpoint.                                                | Required |
-| `DEFAULT_VIEW`      | Standard view for snippets. (Supported values are 'code', 'reader', or 'raw')              | Required |
-| `BASE_URL`          | Base URL for this instance. Necessary behind a reverse proxy. E.g., `https://example.com`. | Required |
-| `HOST`              | Hostname for this instance. E.g., `example.com`.                                           | Required |
-| `API_KEY`           | Password token for the API. If not set, the API is publicly available.                     | Optional |
-| `BRAND`             | Name of the ExBin instance. Shown in bottom right corner when creating a snippet.          | `ExBin`  |
+| Environment var     | Description                                                                                | Default             |
+|---------------------|--------------------------------------------------------------------------------------------|---------------------|
+| `SECRET_KEY_BASE`   | Secret hash to encrypt traffic. Generate with `mix phx.gen.secret`.                        | Required            |
+| `SECRET_SALT`       | Secret hash to encrypt traffic. Generate with `mix phx.gen.secret`.                        | Required            |
+| `DATABASE_HOST`     | Host for database.                                                                         | Required            |
+| `DATABASE_DB`       | Name of the database.                                                                      | Required            |
+| `DATABASE_USER`     | Username for Postgres instance.                                                            | Required            |
+| `DATABASE_PASSWORD` | Password for Postgres user.                                                                | Required            |
+| `POOL_SIZE`         | Concurrent database connections.                                                           | `10`                |
+| `TZ`                | TZ database name                                                                           | Required            |
+| `EPHEMERAL_AGE`     | Ephemeral age of snippets in minutes.                                                      | `60`                |
+| `HTTP_PORT`         | Port for HTTP endpoint.                                                                    | `4000`              |
+| `TCP_PORT`          | Port for the TCP endpoint.                                                                 | Required            |
+| `TCP_HOST`          | IP to bind on for TCP socket.                                                              | Required            |
+| `MAX_SIZE`          | Maximum size in bytes for the TCP endpoint.                                                | Required            |
+| `DEFAULT_VIEW`      | Standard view for snippets. (Supported values are 'code', 'reader', or 'raw')              | Required            |
+| `BASE_URL`          | Base URL for this instance. Necessary behind a reverse proxy. E.g., `https://example.com`. | Required            |
+| `HOST`              | Hostname for this instance. E.g., `example.com`.                                           | Required            |
+| `API_KEY`           | Password token for the API. If not set, the API is publicly available.                     | Optional            |
+| `BRAND`             | Name of the ExBin instance. Shown in bottom right corner when creating a snippet.          | `ExBin`             |
+| `CUSTOM_LOGO_PATH`  | The full path on the host machine to your custom logo. E.g. "/srv/exbin/my_logo.png"       | Optional            |
+| `CUSTOM_LOGO_SIZE`  | The pixel dimensions of your logo, which is assumed to be square. Ignored if no logo set.  | `30`                |
+
 
 Create an .env file and give a value to all these environment variables. You can leave the ones with default values as is, if you want.
 An example is shown below.
@@ -66,16 +69,30 @@ HOST=example.com
 DATABASE_DATA=/tmp/exbindata
 API_KEY=mysupersecretkey
 BRAND=ExBin
+CUSTOM_LOGO_PATH=/exbin_branding/my_cool_logo.png
+CUSTOM_LOGO_SIZE=50
 ```
 
 Copy the `docker-compose.yaml` file, and change accordingly. Finally, run it with `docker-compose up`.
 
 ## Custom Branding in Docker 
 
-To create a custom logo when you use Docker do the following. Let's assume your logo is located on your host at `/path/my_logo.png`. 
-Additionally, the version of ExBin you are running is 0.1.3 (you can see this on the about page).
-To overwrite the logo, mount your file as a volume at `/app/lib/exbin-0.1.3/priv/static/images/logo.png`. 
-This will overwrite the logo with your own.
+In order to configure this you will need to mount the file into your docker container as a volume, and then set the CUSTOM_LOGO_PATH environment variable to the full path (inside the container) that the file is mounted at.  
+Here is an example of what you would add to your docker-compose.yml:
+```
+services:
+  exbin:
+    environment:
+      CUSTOM_LOGO_PATH=/exbin_branding/my_cool_logo.png
+      CUSTOM_LOGO_SIZE=50
+    volumes:
+      - /path/on/docker/host/my_logo.png:/exbin_branding/logo.png
+```
+
+    
+Logo by default is 30x30 pixels, but you can define the size for the width/height attributes of the img tag by setting CUSTOM_LOGO_SIZE.  
+Logos are assumed to be square, so the same value will be used for both height and width.  
+Any layout errors that come from using sizes other than 30x30 are your problem. :-)
 
 # Things To Do 
 
@@ -83,7 +100,6 @@ This will overwrite the logo with your own.
  * Synced paged back or not? 
  * Rate limit the amount of pastes a user can make.
  * Admin page
- * Custom logos
  * Nicer warnings/checks on environment variables instead of crashing immediately.
  * Check older issues to see what I missed
  * Allow a unique user (reuse from rate limiting) to delete a snippet in the next x minutes, or create a unique delete link or something.

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,7 @@ use Mix.Config
 config :exbin,
   ecto_repos: [ExBin.Repo]
 
+
 # Configures the endpoint
 config :exbin, ExBinWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -100,3 +100,10 @@ apikey = System.get_env("API_KEY") || raise "environment variable API_KEY is mis
 
 config :exbin,
   apikey: apikey
+
+#############################################################################
+# Custom Logo
+
+config :exbin,
+  custom_logo_path: System.get_env("CUSTOM_LOGO_PATH"),
+  custom_logo_size: System.get_env("CUSTOM_LOGO_SIZE") || "30"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,8 +32,6 @@ services:
       - ${TCP_PORT}:${TCP_PORT}
     networks:
       - internal
-    volumes: 
-      - /tmp/my_logo.png:/app/lib/exbin-0.1.3/priv/static/images/logo.png
     depends_on:
       - db
 

--- a/lib/exbin_web/controllers/page_controller.ex
+++ b/lib/exbin_web/controllers/page_controller.ex
@@ -5,4 +5,10 @@ defmodule ExBinWeb.PageController do
     conn
     |> render("about.html")
   end
+
+  def static_file_not_found(conn, _params) do
+    conn
+    |> put_status(404)
+    |> text("File Not Found")
+  end
 end

--- a/lib/exbin_web/live/page_live.ex
+++ b/lib/exbin_web/live/page_live.ex
@@ -7,6 +7,7 @@ defmodule ExBinWeb.PageLive do
     {:ok, assign(socket, query: "", snippets: [])}
   end
 
+  @impl true
   def handle_event("suggest", %{"q" => query}, socket) do
     snippets = ExBin.Snippets.search(query)
     Logger.debug("#{Enum.count(snippets)} results for query `#{query}`")

--- a/lib/exbin_web/plug/custom_logo.ex
+++ b/lib/exbin_web/plug/custom_logo.ex
@@ -1,0 +1,30 @@
+defmodule ExBinWeb.Plug.CustomLogo do
+  @moduledoc """
+  Allows defining a path via Application configuration that will be served from
+  the filesystem.
+  """
+  alias Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(%Conn{request_path: "/files/" <> requested_filename} = conn, _opts) do
+    with {:ok, dirname, basename} <- custom_logo_paths_tuple(),
+         true <- String.equivalent?(requested_filename, basename)
+    do
+      Plug.run(conn, [{Plug.Static, [at: "/files", from: dirname, only: [basename]]}])
+    else
+      _ -> conn
+    end
+  end
+
+  # Note that the shortest possible path is "/d/f". This may potentially be
+  # incorrect if running on different platforms, or maybe in specific relative
+  # path scenarios, however we will issue an injunction to the user to use only
+  # absolute paths anyway, so this should be fine...
+  defp custom_logo_paths_tuple() do
+    case Application.get_env(:exbin, :custom_logo_path) do
+      path when is_bitstring(path) and byte_size(path) > 4 -> {:ok, Path.dirname(path), Path.basename(path)}
+      _ -> nil
+    end
+  end
+end

--- a/lib/exbin_web/plug/file_not_found.ex
+++ b/lib/exbin_web/plug/file_not_found.ex
@@ -1,0 +1,12 @@
+defmodule ExBinWeb.Plug.FileNotFound do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(404, "File Not Found")
+    |> halt
+  end
+end

--- a/lib/exbin_web/router.ex
+++ b/lib/exbin_web/router.ex
@@ -15,6 +15,16 @@ defmodule ExBinWeb.Router do
     plug ExBinWeb.ApiAuth, exclude: []
   end
 
+  pipeline :custom_files do
+    plug ExBinWeb.Plug.CustomLogo
+  end
+
+  scope "/files", ExBinWeb do
+    pipe_through [:custom_files]
+    match :*, "/*not_found", Plug.FileNotFound, []
+  end
+
+
   scope "/api", ExBinWeb do
     pipe_through :api
 

--- a/lib/exbin_web/templates/layout/root.html.eex
+++ b/lib/exbin_web/templates/layout/root.html.eex
@@ -189,7 +189,11 @@
           <!-- Menu Bottom  -->
           <div class="menu-column-bottom">
             <div class="menu-entry branding">
-              <img src="<%= Routes.static_path(@conn, "/images/logo.png") %>" width="30" height="30" class="d-inline-block align-top" alt="">
+              <%= if Application.get_env(:exbin, :custom_logo_path) do %>
+                <img src="<%= Routes.static_path(@conn, "/files/#{Path.basename(Application.get_env(:exbin, :custom_logo_path))}") %>" width="<%= Application.get_env(:exbin, :custom_logo_size) %>" height="<%= Application.get_env(:exbin, :custom_logo_size) %>" class="d-inline-block align-top" alt="">
+              <% else %>
+                <img src="<%= Routes.static_path(@conn, "/images/logo.png") %>" width="30" height="30" class="d-inline-block align-top" alt="">
+              <% end %>
               <h5><%= Application.get_env(:exbin, :brand) %></h5>
             </div>
           </div>

--- a/test/exbin_web/controllers/page_controller_test.exs
+++ b/test/exbin_web/controllers/page_controller_test.exs
@@ -1,8 +1,9 @@
 defmodule ExBinWeb.PageControllerTest do
-  use ExBinWeb.ConnCase
+  use ExBinWeb.ConnCase, async: true
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
     assert html_response(conn, 200) =~ "ExBin Development"
   end
+
 end

--- a/test/exbin_web/plug/static_files_pipeline_test.exs
+++ b/test/exbin_web/plug/static_files_pipeline_test.exs
@@ -1,0 +1,78 @@
+defmodule ExBinWeb.Plug.StaticFilesPipelineTest do
+  # I don't like that this test is designed to test the entire pipeline,
+  # including CustomLogo plug and NotFound plug, as well as any future
+  # custom files things, however they're pretty inter-linked and we need
+  # to be able to do all-up integration tests, so this seems like the
+  # best way to do it.
+
+  defmodule IfNoCustomLogoSet do
+    use ExBinWeb.ConnCase, async: true
+
+    describe "application layout" do
+      test "sets correct logo path and dimensions if no custom logo path set", %{conn: conn} do
+        conn = get(conn, "/")
+        assert html_response(conn, 200) =~ "src=\"/images/logo.png\" width=\"30\" height=\"30\""
+      end
+
+      test "default logo is available", %{conn: conn} do
+        # This test is here because it tests that our *normal* Plug.Static for assets is working correctly with the correct paths
+        conn = get(conn, "/images/logo.png")
+        assert {"content-type", "image/png"} in conn.resp_headers
+      end
+    end
+  end
+
+  defmodule WithCustomLogoSet do
+    use ExBinWeb.ConnCase, async: false
+    import ExBin.Factory
+
+    setup do
+      orig_custom_logo_path = Application.get_env(:exbin, :custom_logo_path)
+      orig_custom_logo_size = Application.get_env(:exbin, :custom_logo_size)
+
+      # Because the plug doesn't actually care about the file type we can use a
+      # plain text file, which will be easier to validate.
+      test_file = "/tmp/exbin_static_#{:rand.uniform()}/test_#{:rand.uniform()}.txt"
+      File.mkdir!(Path.dirname(test_file))
+      File.write!(test_file, "#{test_file}")
+      Application.put_env(:exbin, :custom_logo_path, test_file)
+
+      on_exit(fn -> 
+        Application.put_env(:exbin, :custom_logo_path, orig_custom_logo_path)
+        Application.put_env(:exbin, :custom_logo_size, orig_custom_logo_size)
+        File.rm!(test_file)
+        File.rmdir!(Path.dirname(test_file))
+      end)
+
+      {:ok, test_file_path: test_file}
+    end
+      
+    test "does not interfere with snippets starting with the string 'files'", %{conn: conn} do
+      insert!(:snippet, %{name: "filesAreCool", content: "filesAreCool works great!"})
+      conn = get(conn, "/filesAreCool")
+      assert html_response(conn, 200) =~ "filesAreCool works great!"
+    end
+
+    test "properly sets custom logo path and dimensions in the layout", %{conn: conn} do
+      r = :rand.uniform()
+      s = Enum.random(10..50)
+      Application.put_env(:exbin, :custom_logo_path, "/tmp/test_logo_filename_#{r}.png")
+      Application.put_env(:exbin, :custom_logo_size, s)
+      conn = get(conn, "/")
+      assert html_response(conn, 200) =~ "src=\"/files/test_logo_filename_#{r}.png\" width=\"#{s}\" height=\"#{s}\""
+    end
+
+    test "correctly shows error if requested file not in static path", %{conn: conn} do
+      conn = get(conn, "/files/definitely_not_a_file_#{:rand.uniform()}.not-a-png")
+      assert text_response(conn, 404) == "File Not Found"
+    end
+
+    test "correctly serves file from static folder if proper path given", %{conn: conn, test_file_path: test_file} do
+      conn = get(conn, "/files/#{Path.basename(test_file)}")
+
+      assert conn.state == :file
+      assert conn.status == 200
+      assert conn.resp_body == test_file #The file is created with it's own path as the contents so that we can verify we've got the right one
+    end
+  end
+end


### PR DESCRIPTION
Add an optionally configured Plug.Static to serve a single file, if the CUSTOM_LOGO_PATH environment variable is set.

This adds tests to ensure that things are behaving the way we want on the application side, but what it can't test is the releases.exs/docker configuration.
It would be valuable to run a quick sanity check on a built docker image of this, with the appropriate values set, just to make sure that's working, before pushing a release. (I have not done so as it would be better to make sure that it's working correctly with the specific build steps you use.)

Also includes a minor documentation fix and compiler warning fix.

Resolves #37